### PR TITLE
🔧 Update path matching in dotnet-release workflow

### DIFF
--- a/.github/workflows/dotnet-release.yml
+++ b/.github/workflows/dotnet-release.yml
@@ -11,7 +11,7 @@ on:
       - main
     # and if mod-loader-solution is changed at all
     paths:
-      - 'mod-loader/mod-loader-solution/*'
+      - 'mod-loader/mod-loader-solution/**'
 jobs:
   build:
     runs-on: windows-2019


### PR DESCRIPTION
This now follows recursive subdirectories instead of immediate subdirectories